### PR TITLE
chore: update styled-reset

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "react-toastify": "^4.5.2",
     "rl-react-helmet": "^5.2.0",
     "styled-components": "^4.1.3",
-    "styled-reset": "^2.0.0"
+    "styled-reset": "^4.0.7"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9505,10 +9505,10 @@ styled-components@^4.1.3:
     stylis-rule-sheet "^0.0.10"
     supports-color "^5.5.0"
 
-styled-reset@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/styled-reset/-/styled-reset-2.0.0.tgz#a52d4c40a0b529e1afdb2d67cb2bcc4d781de123"
-  integrity sha512-qiVsQPdfTn5aERpW1ucJlyt399ywKKOdRVAFsWzv9s+DKTmAscTzCHRNb2672GADD4rggxRAEXrhi63k3tLCrQ==
+styled-reset@^4.0.7:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/styled-reset/-/styled-reset-4.0.7.tgz#6f08bfb0ef92ec01104b94d444e149fb7294d16f"
+  integrity sha512-RgTDn8NXkoUZmRROS4innWB0ZryCnGAbFfN+cSKK84GDnl/GU4O5UNSyFAzxkNiYq4CyW/WYFe33W8wlHVBu+Q==
   dependencies:
     opencollective "^1.0.3"
     opencollective-postinstall "2.0.2"


### PR DESCRIPTION
The version you're on is a bit outdated, and there's been a license change since then. This updates to the current version. I think forks/clones of this repo are the main source of styled-reset installs so this will help keep them up to date, too.